### PR TITLE
Add warning about using mmaparrays keyword

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -200,6 +200,7 @@ read_bytestring(io::IOStream) = String(readuntil(io, 0x00))
 const OPEN_FILES = Dict{String,WeakRef}()
 function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, iotype::T=MmapIO;
                  compress::Bool=false, mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}
+    mmaparrays && @warn "mmaparrays keyword is currently ignored" maxlog=1
     exists = isfile(fname)
     if exists
         rname = realpath(fname)


### PR DESCRIPTION
This has caused me a great deal of grief as it currently silently ignores the `mmaparrays` keyword.